### PR TITLE
[scripts-contextmenu_gui] 修复图形菜单脚本中的空值检测

### DIFF
--- a/portable_config/scripts/contextmenu_gui/main.lua
+++ b/portable_config/scripts/contextmenu_gui/main.lua
@@ -56,7 +56,7 @@ end
 -- Edition menu functions
 local function enableEdition()
     local editionState = false
-    if (propNative("edition-list/count") < 1) then editionState = true end
+    if (propNative("edition-list/count") ~= nil and propNative("edition-list/count") < 1) then editionState = true end
     return editionState
 end
 
@@ -79,7 +79,7 @@ local function editionMenu()
             table.insert(editionMenuVal, {RADIO, editionTitle, "", editionCommand, function() return checkEdition(editionNum) end, false})
         end
     else
-        if (editionNum == 0) then table.insert(editionMenuVal, {SEP}) end
+        table.insert(editionMenuVal, {COMMAND, "No Editions", "", "", "", true})
     end
 
     return editionMenuVal
@@ -88,7 +88,7 @@ end
 -- Chapter menu functions
 local function enableChapter()
     local chapterEnable = false
-    if (propNative("chapter-list/count") < 1) then chapterEnable = true end
+    if (propNative("chapter-list/count") ~= nil and propNative("chapter-list/count") < 1) then chapterEnable = true end
     return chapterEnable
 end
 


### PR DESCRIPTION
修复"edition-list/count"和"chapter-list/count"的空值检测，避免mpv打印警告
还原 https://github.com/hooke007/MPV_lazy/commit/cd38811dd135e2199740885609b75c876219148f 中的错误修改