### PR TITLE
[scripts-contextmenu_gui] 修复图形化菜单脚本的当前edition状态显示

### DIFF
--- a/portable_config/scripts/contextmenu_gui/main.lua
+++ b/portable_config/scripts/contextmenu_gui/main.lua
@@ -53,17 +53,17 @@ local function round(num, numDecimalPlaces)
     return tonumber(string.format("%." .. (numDecimalPlaces or 0) .. "f", num))
 end
 
--- Edition menu functions
-local function enableEdition()
-    local editionState = false
-    if (propNative("edition-list/count") ~= nil and propNative("edition-list/count") < 1) then editionState = true end
-    return editionState
+-- 版本（Edition）子菜单
+local function inspectEdition()
+    local editionDisable = false
+    if (propNative("edition-list/count") ~= nil and propNative("edition-list/count") < 1) then editionDisable = true end
+    return editionDisable
 end
 
 local function checkEdition(editionNum)
-    local editionEnable, editionCur = false, propNative("edition")
-    if (editionNum == editionCur) then editionEnable = true end
-    return editionEnable
+    local editionState, editionCur = false, propNative("current-edition")
+    if (editionNum == editionCur) then editionState = true end
+    return editionState
 end
 
 local function editionMenu()
@@ -85,11 +85,11 @@ local function editionMenu()
     return editionMenuVal
 end
 
--- Chapter menu functions
-local function enableChapter()
-    local chapterEnable = false
-    if (propNative("chapter-list/count") ~= nil and propNative("chapter-list/count") < 1) then chapterEnable = true end
-    return chapterEnable
+-- 章节子菜单
+local function inspectChapter()
+    local chapterDisable = false
+    if (propNative("chapter-list/count") ~= nil and propNative("chapter-list/count") < 1) then chapterDisable = true end
+    return chapterDisable
 end
 
 local function checkChapter(chapterNum)
@@ -150,10 +150,10 @@ local function checkTrack(trackNum)
 end
 
 -- 视频轨子菜单
-local function enableVidTrack()
-    local vidTrackEnable, vidTracks = false, trackCount("video")
-    if (#vidTracks < 1) then vidTrackEnable = true end
-    return vidTrackEnable
+local function inspectVidTrack()
+    local vidTrackDisable, vidTracks = false, trackCount("video")
+    if (#vidTracks < 1) then vidTrackDisable = true end
+    return vidTrackDisable
 end
 
 local function vidTrackMenu()
@@ -592,8 +592,8 @@ mp.register_event("file-loaded", function()
             {COMMAND, "下一帧", "", "frame-step", "", false, true},
             {COMMAND, "后退10秒", "", "seek -10", "", false, true},
             {COMMAND, "前进10秒", "", "seek 10", "", false, true},
-            {CASCADE, "版本（Edition）", "edition_menu", "", "", function() return enableEdition() end},
-            {CASCADE, "章节", "chapter_menu", "", "", function() return enableChapter() end},
+            {CASCADE, "版本（Edition）", "edition_menu", "", "", function() return inspectEdition() end},
+            {CASCADE, "章节", "chapter_menu", "", "", function() return inspectChapter() end},
         },
 
         -- Use functions returning tables, since we don't need these menus if there aren't any editions or any chapters to seek through.
@@ -634,7 +634,7 @@ mp.register_event("file-loaded", function()
 
 -- 二级菜单 —— 视频
         video_menu = {
-            {CASCADE, "轨道", "vidtrack_menu", "", "", function() return enableVidTrack() end},
+            {CASCADE, "轨道", "vidtrack_menu", "", "", function() return inspectVidTrack() end},
             {SEP},
             {CASCADE, "解码模式", "hwdec_menu", "", "", false},
             {CHECK, "去色带", "", "cycle deband", function() return propNative("deband") end, false},


### PR DESCRIPTION
修正并统一变量用语习惯
~优化edition子菜单启用条件，实际使用中单edition无需显示~
editionCur改为检测"current-edition"值，"edition"值无法匹配editionNum导致当前edition状态显示不正确