### PR TITLE
[scripts-contextmenu_gui] 图形化菜单脚本：大型重构

### DIFF
--- a/portable_config/scripts/contextmenu_gui/main.lua
+++ b/portable_config/scripts/contextmenu_gui/main.lua
@@ -53,10 +53,47 @@ local function round(num, numDecimalPlaces)
     return tonumber(string.format("%." .. (numDecimalPlaces or 0) .. "f", num))
 end
 
+-- 播放列表子菜单
+local function inspectPlaylist()
+    local playlistDisable = false
+    if propNative("playlist/count") == nil or  propNative("playlist/count") < 1 then playlistDisable = true end
+    return playlistDisable
+end
+
+local function checkplaylist(playlistNum)
+    local playlistState, playlistCur = false, propNative("playlist-pos")
+    if (playlistNum == playlistCur) then playlistState = true end
+    return playlistState
+end
+
+local function playlistMenu()
+    local playlistCount = propNative("playlist/count")
+    local playlistMenuVal = {}
+
+    if playlistCount ~= nil and not (playlistCount == 0) then
+        for playlistNum=0, (playlistCount - 1), 1 do
+            local playlistTitle = propNative("playlist/" .. playlistNum .. "/title")
+            local playlistFilename = propNative("playlist/" .. playlistNum .. "/filename")
+            if playlistFilename:match("://") then table.insert(playlistMenuVal, {COMMAND, "不支持串流文件", "", "", "", true})
+            else
+                local playlistFilename = playlistFilename:gsub("\\", "/")
+                local playlistFilename = playlistFilename:gsub("^.*/", "")
+                if string.len(playlistFilename) > 80 then playlistFilename = string.sub(playlistFilename, 1, 80) .. "..." end
+                if not (playlistTitle) then playlistTitle = playlistFilename end
+
+                local playlistCommand = "set playlist-pos " .. playlistNum
+                table.insert(playlistMenuVal, {RADIO, playlistTitle, "", playlistCommand, function() return checkplaylist(playlistNum) end, false})
+            end
+        end
+    end
+
+    return playlistMenuVal
+end
+
 -- 版本（Edition）子菜单
 local function inspectEdition()
     local editionDisable = false
-    if (propNative("edition-list/count") ~= nil and propNative("edition-list/count") < 1) then editionDisable = true end
+    if propNative("edition-list/count") == nil or propNative("edition-list/count") < 1 then editionDisable = true end
     return editionDisable
 end
 
@@ -70,16 +107,14 @@ local function editionMenu()
     local editionCount = propNative("edition-list/count")
     local editionMenuVal = {}
 
-    if not (editionCount == 0) then
+    if editionCount ~= nil and not (editionCount == 0) then
         for editionNum=0, (editionCount - 1), 1 do
             local editionTitle = propNative("edition-list/" .. editionNum .. "/title")
-            if not (editionTitle) then editionTitle = "Edition " .. (editionNum + 1) end
+            if not (editionTitle) then editionTitle = "Edition " .. string.format("%02.f", editionNum + 1) end
 
             local editionCommand = "set edition " .. editionNum
             table.insert(editionMenuVal, {RADIO, editionTitle, "", editionCommand, function() return checkEdition(editionNum) end, false})
         end
-    else
-        table.insert(editionMenuVal, {COMMAND, "No Editions", "", "", "", true})
     end
 
     return editionMenuVal
@@ -88,7 +123,7 @@ end
 -- 章节子菜单
 local function inspectChapter()
     local chapterDisable = false
-    if (propNative("chapter-list/count") ~= nil and propNative("chapter-list/count") < 1) then chapterDisable = true end
+    if propNative("chapter-list/count") == nil or propNative("chapter-list/count") < 1 then chapterDisable = true end
     return chapterDisable
 end
 
@@ -106,10 +141,15 @@ local function chapterMenu()
         {COMMAND, "上一章节", "", "add chapter -1", "", false, true},
         {COMMAND, "下一章节", "", "add chapter 1", "", false, true},
     }
-    if not (chapterCount == 0) then
+    if chapterCount ~= nil and not (chapterCount == 0) then
         for chapterNum=0, (chapterCount - 1), 1 do
             local chapterTitle = propNative("chapter-list/" .. chapterNum .. "/title")
-            if not (chapterTitle) then chapterTitle = "章节 " .. (chapterNum + 1) end
+            local chapterTime = propNative("chapter-list/" .. chapterNum .. "/time")
+            if chapterTitle == "" then chapterTitle = "章节 " .. string.format("%02.f", chapterNum + 1) end
+            if chapterTime < 0 then chapterTime = 0
+            else chapterTime = math.floor(chapterTime) end
+            chapterTime = string.format("[%02d:%02d:%02d]", math.floor(chapterTime/60/60), math.floor(chapterTime/60)%60, chapterTime%60)
+            chapterTitle = chapterTime ..'   '.. chapterTitle
 
             local chapterCommand = "set chapter " .. chapterNum
             if (chapterNum == 0) then table.insert(chapterMenuVal, {SEP}) end
@@ -149,6 +189,36 @@ local function checkTrack(trackNum)
     return trackState
 end
 
+-- Convert ISO 639-1/639-2 codes to be full length language names. The full length names
+-- are obtained by using the property accessor with the iso639_1/_2 tables stored in
+-- the contextmenu_gui_lang.lua file (require "langcodes" above).
+local function getLang(trackLang)
+    trackLang = string.upper(trackLang)
+    if (string.len(trackLang) == 2) then trackLang = langcodes.iso639_1(trackLang)
+    elseif (string.len(trackLang) == 3) then trackLang = langcodes.iso639_2(trackLang) end
+    return trackLang
+end
+
+local function noneCheck(checkType)
+    local checkVal, trackID = false, propNative(checkType)
+    if (type(trackID) == "boolean") then
+        if (trackID == false) then checkVal = true end
+    end
+    return checkVal
+end
+
+local function esc_for_title(string)
+    string = string:gsub('^%-', '')
+    :gsub('^%_', '')
+    :gsub('^%.', '')
+    :gsub('^.*%].', '')
+    :gsub('^.*%).', '')
+    :gsub('%.%w+$', '')
+    :gsub('^.*%s', '')
+    :gsub('^.*%.', '')
+    return string
+end
+
 -- 视频轨子菜单
 local function inspectVidTrack()
     local vidTrackDisable, vidTracks = false, trackCount("video")
@@ -171,6 +241,10 @@ local function vidTrackMenu()
             local vidTrackDefault = propNative("track-list/" .. vidTrackNum .. "/default")
             local vidTrackForced = propNative("track-list/" .. vidTrackNum .. "/forced")
             local vidTrackExternal = propNative("track-list/" .. vidTrackNum .. "/external")
+            local filename = propNative("filename/no-ext")
+
+            if vidTrackTitle then vidTrackTitle = vidTrackTitle:gsub(filename, '') end
+            if vidTrackExternal then vidTrackTitle = esc_for_title(vidTrackTitle) end
             if vidTrackCodec:match("MPEG2") then vidTrackCodec = "MPEG2"
             elseif vidTrackCodec:match("DVVIDEO") then vidTrackCodec = "DV"
             end
@@ -194,36 +268,13 @@ local function vidTrackMenu()
     return vidTrackMenuVal
 end
 
--- Convert ISO 639-1/639-2 codes to be full length language names. The full length names
--- are obtained by using the property accessor with the iso639_1/_2 tables stored in
--- the contextmenu_gui_lang.lua file (require "langcodes" above).
-function getLang(trackLang)
-    trackLang = string.upper(trackLang)
-    if (string.len(trackLang) == 2) then trackLang = langcodes.iso639_1(trackLang)
-    elseif (string.len(trackLang) == 3) then trackLang = langcodes.iso639_2(trackLang) end
-    return trackLang
-end
-
-function noneCheck(checkType)
-    local checkVal, trackID = false, propNative(checkType)
-    if (type(trackID) == "boolean") then
-        if (trackID == false) then checkVal = true end
-    end
-    return checkVal
-end
-
-function esc_for_title(s)
-    s = string.gsub(s, '^%-', '')
-    s = string.gsub(s, '^%_', '')
-    s = string.gsub(s, '^%.', '')
-    s = string.gsub(s, '^.*%].', '')
-    s = string.gsub(s, '^.*%).', '')
-    s = string.gsub(s, '%.%w+$', '')
-    s = string.gsub(s, '^.*%.', '')
-    return s
-end
-
 -- 音频轨子菜单
+local function inspectAudTrack()
+    local audTrackDisable, audTracks = false, trackCount("audio")
+    if (#audTracks < 1) then audTrackDisable = true end
+    return audTrackDisable
+end
+
 local function audTrackMenu()
     local audTrackMenuVal, audTrackCount = {}, trackCount("audio")
 
@@ -238,8 +289,8 @@ local function audTrackMenu()
             local audTrackTitle = propNative("track-list/" .. audTrackNum .. "/title")
             local audTrackLang = propNative("track-list/" .. audTrackNum .. "/lang")
             local audTrackCodec = propNative("track-list/" .. audTrackNum .. "/codec"):upper()
-            -- local audTrackBitrate = propNative("track-list/" .. audTrackNum .. "/demux-bitrate") / 1000  -- 此属性似乎不可用
-            local audTrackSamplerate = propNative("track-list/" .. audTrackNum .. "/demux-samplerate") / 1000
+            -- local audTrackBitrate = propNative("track-list/" .. audTrackNum .. "/demux-bitrate")/1000  -- 此属性似乎不可用
+            local audTrackSamplerate = string.format("%.1f", propNative("track-list/" .. audTrackNum .. "/demux-samplerate")/1000)
             local audTrackChannels = propNative("track-list/" .. audTrackNum .. "/demux-channel-count")
             local audTrackDefault = propNative("track-list/" .. audTrackNum .. "/default")
             local audTrackForced = propNative("track-list/" .. audTrackNum .. "/forced")
@@ -272,10 +323,16 @@ local function audTrackMenu()
     return audTrackMenuVal
 end
 
+-- 字幕轨子菜单
+local function inspectSubTrack()
+    local subTrackDisable, subTracks = false, trackCount("sub")
+    if (#subTracks < 1) then subTrackDisable = true end
+    return subTrackDisable
+end
+
 -- Subtitle label
 local function subVisLabel() return propNative("sub-visibility") and "隐藏" or "取消隐藏" end
 
--- 字幕轨子菜单
 local function subTrackMenu()
     local subTrackMenuVal, subTrackCount = {}, trackCount("sub")
 
@@ -584,9 +641,6 @@ menuList = {
 -- If mpv enters a stopped state, change the change the menu back to the "no file loaded" menu
 -- so that it will still popup.
 menuListBase = menuList
-mp.register_event("end-file", function()
-    menuList = menuListBase
-end)
 
 -- DO NOT create the "playing" menu tables until AFTER the file has loaded as we're unable to
 -- dynamically create some menus if it tries to build the table before the file is loaded.
@@ -662,11 +716,13 @@ local function playmenuList()
             {COMMAND, "下一帧", "", "frame-step", "", false, true},
             {COMMAND, "后退10秒", "", "seek -10", "", false, true},
             {COMMAND, "前进10秒", "", "seek 10", "", false, true},
+            {CASCADE, "播放列表", "playlist_menu", "", "", function() return inspectPlaylist() end},
             {CASCADE, "版本（Edition）", "edition_menu", "", "", function() return inspectEdition() end},
             {CASCADE, "章节", "chapter_menu", "", "", function() return inspectChapter() end},
         },
 
         -- Use functions returning tables, since we don't need these menus if there aren't any editions or any chapters to seek through.
+        playlist_menu = playlistMenu(),
         edition_menu = editionMenu(),
         chapter_menu = chapterMenu(),
 
@@ -769,7 +825,7 @@ local function playmenuList()
 
 -- 二级菜单 —— 音频
         audio_menu = {
-            {CASCADE, "轨道", "audtrack_menu", "", "", false},
+            {CASCADE, "轨道", "audtrack_menu", "", "", function() return inspectAudTrack() end},
             {SEP},
             {COMMAND, "音量 -1", "", "add volume -1", "", false, true},
             {COMMAND, "音量 +1", "", "add volume  1", "", false, true},
@@ -790,7 +846,7 @@ local function playmenuList()
 
 -- 二级菜单 —— 字幕
         subtitle_menu = {
-            {CASCADE, "轨道", "subtrack_menu", "", "", false},
+            {CASCADE, "轨道", "subtrack_menu", "", "", function() return inspectSubTrack() end},
             {SEP},
             {COMMAND, "重置", "", "no-osd set sub-delay 0; no-osd set sub-pos 100; no-osd set sub-scale 1.0", "", false},
             {COMMAND, "字号 -0.1", "", "add sub-scale -0.1", "", false, true},
@@ -896,10 +952,22 @@ local function playmenuList()
     end
 end
 
-mp.register_event("file-loaded", playmenuList)
-mp.observe_property("track-list/count", "number", function()
-    local track_count = mp.get_property_number("track-list/count")
-    if track_count ~= nil and track_count > 0 then playmenuList() end
+mp.add_hook("on_preloaded", 100, playmenuList)
+
+local function observe_change()
+    mp.observe_property("track-list/count", "number", playmenuList)
+    mp.observe_property("chapter-list/count", "number", playmenuList)
+    mp.observe_property("playlist/count", "number", playmenuList)
+    mp.observe_property("playlist-shuffle", nil, playmenuList)
+    mp.observe_property("playlist-unshuffle", nil, playmenuList)
+    mp.observe_property("playlist-move", nil, playmenuList)
+end
+
+mp.register_event("file-loaded", observe_change)
+
+mp.register_event("end-file", function()
+    mp.unobserve_property(playmenuList)
+    menuList = menuListBase
 end)
 
 --[[ ************ 菜单内容 ************ ]]--


### PR DESCRIPTION
- [x] 添加播放列表子菜单：忽略串流文件（获取不到正确的文件名），限制文件名长度为80，超过时截断，防止菜单溢出
- [x] 修复edition列表和章节列表为空时导致的脚本致命错误（发生在空闲状态及串流文件中）
- [x] 优化音频子菜单和字幕子菜单的显隐控制
- [x] 除轨道列表外，增加监视章节列表和播放列表的变动以便重绘菜单
- [x] 重构图形化菜单的触发及渲染方式