### PR TITLE
[scripts-uosc] 增加“次字幕轨列表”菜单项

### DIFF
--- a/portable_config/input_uosc.conf
+++ b/portable_config/input_uosc.conf
@@ -11,7 +11,7 @@
 #                  script-binding uosc/video                             #! 导航 > ※ 视频轨列表
 #                  script-binding uosc/audio                             #! 导航 > ※ 音频轨列表
 #                  script-binding uosc/subtitles                         #! 导航 > ※ 字幕轨列表
-#                  script-binding uosc/secondary-subtitles               #! 导航 > ※ 次字幕轨列表
+#                  script-binding uosc/subtitles-sec                     #! 导航 > ※ 次字幕轨列表
 #                  playlist-shuffle                                      #! 导航 > 播放列表乱序重排
 
 #                  script-binding uosc/shot                              #! ※ 截屏

--- a/portable_config/input_uosc.conf
+++ b/portable_config/input_uosc.conf
@@ -11,6 +11,7 @@
 #                  script-binding uosc/video                             #! 导航 > ※ 视频轨列表
 #                  script-binding uosc/audio                             #! 导航 > ※ 音频轨列表
 #                  script-binding uosc/subtitles                         #! 导航 > ※ 字幕轨列表
+#                  script-binding uosc/secondary-subtitles               #! 导航 > ※ 次字幕轨列表
 #                  playlist-shuffle                                      #! 导航 > 播放列表乱序重排
 
 #                  script-binding uosc/shot                              #! ※ 截屏

--- a/portable_config/mpv.conf
+++ b/portable_config/mpv.conf
@@ -62,7 +62,7 @@
  loop-playlist          = no          # <inf|force|默认no> 播放列表循环。值 force 会强制播放列表中标记为失效的条目而不是跳过它
  hr-seek-framedrop      = yes         # [补帧时推荐设置为no] 跳转时允许丢帧，默认 yes 。禁用它利于修正音频延迟
  save-position-on-quit  = no          # 退出时记住播放状态，默认 no
- watch-later-options    = start,speed,edition,volume,mute,audio-delay,gamma,brightness,contrast,saturation,hue,deinterlace,vf,af,panscan,aid,vid,sid,sub-delay,sub-speed,sub-pos,sub-visibility,sub-scale,sub-use-margins,sub-ass-force-margins,sub-ass-vsfilter-aspect-compat,sub-ass-override,secondary-sub-visibility,ab-loop-a,ab-loop-b,video-aspect-override,video-aspect-method,video-unscaled,video-pan-x,video-pan-y,video-rotate,video-crop,video-zoom,video-scale-x,video-scale-y,video-align-x,video-align-y
+ watch-later-options    = start,speed,edition,volume,mute,audio-delay,gamma,brightness,contrast,saturation,hue,deinterlace,vf,af,panscan,aid,vid,sid,secondary-sid,sub-delay,sub-speed,sub-pos,sub-visibility,sub-scale,sub-use-margins,sub-ass-force-margins,sub-ass-vsfilter-aspect-compat,sub-ass-override,secondary-sub-visibility,ab-loop-a,ab-loop-b,video-aspect-override,video-aspect-method,video-unscaled,video-pan-x,video-pan-y,video-rotate,video-crop,video-zoom,video-scale-x,video-scale-y,video-align-x,video-align-y
                                       # [补帧时注意避免记录值 vf ] 稍后观看的属性白名单。示例即默认值
                                       # 推荐精简为 start,aid,vid,sid 以避免与你的核心设置冲突
                                       # 当 --save-position-on-quit=yes 或使用退出时保存到稍后观看的功能时，如果不使用白名单，滤镜列表、音量、速率等其它状态也会被保存并在下次启动时恢复

--- a/portable_config/mpv.conf
+++ b/portable_config/mpv.conf
@@ -62,7 +62,7 @@
  loop-playlist          = no          # <inf|force|默认no> 播放列表循环。值 force 会强制播放列表中标记为失效的条目而不是跳过它
  hr-seek-framedrop      = yes         # [补帧时推荐设置为no] 跳转时允许丢帧，默认 yes 。禁用它利于修正音频延迟
  save-position-on-quit  = no          # 退出时记住播放状态，默认 no
- watch-later-options    = start,speed,edition,volume,mute,audio-delay,gamma,brightness,contrast,saturation,hue,deinterlace,vf,af,panscan,aid,vid,sid,secondary-sid,sub-delay,sub-speed,sub-pos,sub-visibility,sub-scale,sub-use-margins,sub-ass-force-margins,sub-ass-vsfilter-aspect-compat,sub-ass-override,secondary-sub-visibility,ab-loop-a,ab-loop-b,video-aspect-override,video-aspect-method,video-unscaled,video-pan-x,video-pan-y,video-rotate,video-crop,video-zoom,video-scale-x,video-scale-y,video-align-x,video-align-y
+ watch-later-options    = start,speed,edition,volume,mute,audio-delay,gamma,brightness,contrast,saturation,hue,deinterlace,vf,af,panscan,aid,vid,sid,sub-delay,sub-speed,sub-pos,sub-visibility,sub-scale,sub-use-margins,sub-ass-force-margins,sub-ass-vsfilter-aspect-compat,sub-ass-override,secondary-sub-visibility,ab-loop-a,ab-loop-b,video-aspect-override,video-aspect-method,video-unscaled,video-pan-x,video-pan-y,video-rotate,video-crop,video-zoom,video-scale-x,video-scale-y,video-align-x,video-align-y
                                       # [补帧时注意避免记录值 vf ] 稍后观看的属性白名单。示例即默认值
                                       # 推荐精简为 start,aid,vid,sid 以避免与你的核心设置冲突
                                       # 当 --save-position-on-quit=yes 或使用退出时保存到稍后观看的功能时，如果不使用白名单，滤镜列表、音量、速率等其它状态也会被保存并在下次启动时恢复

--- a/portable_config/scripts/uosc/lib/lang.lua
+++ b/portable_config/scripts/uosc/lib/lang.lua
@@ -98,7 +98,7 @@ ulang = {
 	_input_empty = 'input-bindings 为空',
 
 	_sid_submenu_title = '字幕轨列表',
-	_sid_secondary_submenu_title = '次字幕轨列表',
+	_sid_sec_submenu_title = '次字幕轨列表',
 	_aid_submenu_title = '音频轨列表',
 	_vid_submenu_title = '视频轨列表',
 	_playlist_submenu_title = '播放列表',

--- a/portable_config/scripts/uosc/lib/lang.lua
+++ b/portable_config/scripts/uosc/lib/lang.lua
@@ -98,6 +98,7 @@ ulang = {
 	_input_empty = 'input-bindings 为空',
 
 	_sid_submenu_title = '字幕轨列表',
+	_sid_secondary_submenu_title = '次字幕轨列表',
 	_aid_submenu_title = '音频轨列表',
 	_vid_submenu_title = '视频轨列表',
 	_playlist_submenu_title = '播放列表',

--- a/portable_config/scripts/uosc/lib/menus.lua
+++ b/portable_config/scripts/uosc/lib/menus.lua
@@ -126,6 +126,7 @@ function create_select_tracklist_type_menu_opener(menu_title, track_type, track_
 		for _, track in ipairs(tracklist) do
 			if track.type == track_type then
 				local hint_values = {}
+				local selected_by_prop = track.selected and utils.to_string(track.id) == mp.get_property(track_prop)
 				local function h(value) hint_values[#hint_values + 1] = value end
 
 				if track.lang then h(track.lang:upper()) end
@@ -144,10 +145,10 @@ function create_select_tracklist_type_menu_opener(menu_title, track_type, track_
 					title = (track.title and track.title or ulang._submenu_id_title .. track.id),
 					hint = table.concat(hint_values, ', '),
 					value = track.id,
-					active = track.selected,
+					active = selected_by_prop,
 				}
 
-				if track.selected then
+				if selected_by_prop then
 					if disabled_item then disabled_item.active = false end
 					active_index = #items
 				end

--- a/portable_config/scripts/uosc/main.lua
+++ b/portable_config/scripts/uosc/main.lua
@@ -880,8 +880,8 @@ bind_command('load-video', create_track_loader_menu_opener({
 bind_command('subtitles', create_select_tracklist_type_menu_opener(
 	ulang._sid_submenu_title, 'sub', 'sid', 'script-binding uosc/load-subtitles', 'script-binding uosc/download-subtitles'
 ))
-bind_command('secondary-subtitles', create_select_tracklist_type_menu_opener(
-	ulang._sid_secondary_submenu_title, 'sub', 'secondary-sid', 'script-binding uosc/load-subtitles', 'script-binding uosc/download-subtitles'
+bind_command('subtitles-sec', create_select_tracklist_type_menu_opener(
+	ulang._sid_sec_submenu_title, 'sub', 'secondary-sid', 'script-binding uosc/load-subtitles', 'script-binding uosc/download-subtitles'
 ))
 bind_command('audio', create_select_tracklist_type_menu_opener(
 	ulang._aid_submenu_title, 'audio', 'aid', 'script-binding uosc/load-audio'

--- a/portable_config/scripts/uosc/main.lua
+++ b/portable_config/scripts/uosc/main.lua
@@ -880,6 +880,9 @@ bind_command('load-video', create_track_loader_menu_opener({
 bind_command('subtitles', create_select_tracklist_type_menu_opener(
 	ulang._sid_submenu_title, 'sub', 'sid', 'script-binding uosc/load-subtitles', 'script-binding uosc/download-subtitles'
 ))
+bind_command('secondary-subtitles', create_select_tracklist_type_menu_opener(
+	ulang._sid_secondary_submenu_title, 'sub', 'secondary-sid', 'script-binding uosc/load-subtitles', 'script-binding uosc/download-subtitles'
+))
 bind_command('audio', create_select_tracklist_type_menu_opener(
 	ulang._aid_submenu_title, 'audio', 'aid', 'script-binding uosc/load-audio'
 ))


### PR DESCRIPTION
- [x] 增加“次字幕轨列表”菜单项

目前很多流媒体资源自带多语言字幕，应该有像我一样有显示双语字幕需求的朋友，故基于官方`--secondary-sid`属性添加用于选择开启次字幕的菜单。

~另外，默认次字幕位置是在画面上部，要不要考虑调整一下默认主、次字幕的字号和位置？~
算了，尝试了一下，有的字幕是两行的，这样位置和字号就不太好合理安排了，就分布画面上下也能接受。